### PR TITLE
Store the matrix of linking constraints in the sub-problem

### DIFF
--- a/src/SimpleProblem/SimpleProblem.jl
+++ b/src/SimpleProblem/SimpleProblem.jl
@@ -22,18 +22,31 @@ export SimpleSubProblem, SimpleMasterProblem
 
 """
     SimpleSubProblem
-    Concrete implementation of AbstractSubProblem
+A concrete implementation of AbstractSubProblem
+
+# Attributes
+-`costs::AbstractVector{Real}`: native objective in the sub-problem
+-`A_link::AbstractMatrix{Real}`: matrix of the linking constraints,
+    as given by the original formulation
+-`A_sub::AbstractMatrix{Real}`: constraint matrix for the sub-problem
+-`senses::Vector{Char}`: constraints' senses in the sub-problem
+-`b::AbstractVector{Real}`: right-hand side of the sub-problem's constraints
+-`vartypes::AbstractVector{Symbol}`: variables' types
+-`lb::AbstractVector{Real}`: lower bounds on the original variables
+-`ub::AbstractVector{Real}`: upper bounds on the original variables
+-`solver::MathProgBase.AbstractMathProgSolver`: solver for the sub-problem
 """
-mutable struct SimpleSubProblem{N1<:Real,N2<:Real,N3<:Real,N4<:Real,N5<:Real} <: AbstractSubProblem
+mutable struct SimpleSubProblem{N1<:Real,N2<:Real,N3<:Real,N4<:Real,N5<:Real,N6<:Real} <: AbstractSubProblem
     
     # data for sub-problem
     costs::AbstractVector{N1}
-    A::AbstractMatrix{N2}
-    sense::AbstractVector{Char}
-    b::AbstractVector{N3}
+    A_link::AbstractMatrix{N2}
+    A_sub::AbstractMatrix{N3}
+    senses::Vector{Char}
+    b::AbstractVector{N4}
     vartypes::AbstractVector{Symbol}
-    lb::AbstractVector{N4}
-    ub::AbstractVector{N5}
+    lb::AbstractVector{N5}
+    ub::AbstractVector{N6}
     solver::MathProgBase.AbstractMathProgSolver
 end
 
@@ -42,22 +55,22 @@ end
 """
     solve_pricing implementation for SimpleSubProblem
 """
-function solve_pricing(sp::SimpleSubProblem, π::V1, σ::V2, farkas_pricing=false) where {V1<:AbstractVector{N1}, V2<:AbstractVector{N2}} where {N1<:Real, N2<:Real}
+function solve_pricing(sp::SimpleSubProblem, π::AbstractVector{N1}, σ::AbstractVector{N2}, farkas_pricing=false) where {N1<:Real, N2<:Real}
 
     # dimension check
-    size(π, 1) == size(sp.costs, 1) || DimensionMismatch("π's dimension is $(size(π, 1)) but should be $(size(sp.costs, 1))")
+    size(π, 1) == size(sp.A_link, 1) || DimensionMismatch("π's dimension is $(size(π, 1)) but should be $(size(sp.A_link, 1))")
 
     # form perturbed objective for the sub-problem
     if farkas_pricing
-        obj_ = - π
+        obj_ = - sp.A_link' * π
     else
-        obj_ = sp.costs - π
+        obj_ = sp.costs - sp.A_link' * π
     end
 
     # solve sub-problem
     result = MathProgBase.mixintprog(
         obj_,
-        sp.A, sp.sense, sp.b, sp.vartypes, sp.lb, sp.ub, sp.solver
+        sp.A_sub, sp.senses, sp.b, sp.vartypes, sp.lb, sp.ub, sp.solver
     )
     sp_status = find_status(result.status)
 
@@ -76,7 +89,7 @@ function solve_pricing(sp::SimpleSubProblem, π::V1, σ::V2, farkas_pricing=fals
 
     # check that reduced cost is indeed negative
     if rc < - 10.0^-6  # default solver tolerance for reduced costs
-        columns = [Column(cost, col, true, false)]
+        columns = [Column(cost, sp.A_link * col, true, false)]
         # println("\tPricing: found column, rc = $(rc)")
         # println("\t\t", col)
     else
@@ -103,31 +116,39 @@ end
 
 """
     SimpleMasterProblem
-    Concrete implementation of MasterProblem.
+
+# Attributes
+- `b::AbstractVector{T<:Real}`: right-hand side of linking constraints
+- `rmp::MathProgBase.AbstractLinearQuadraticModel`: Restricte Master Problem
+- `sp::AbstractSubProblem`: Sub-Problem
 """
-mutable struct SimpleMasterProblem{ST<:AbstractSubProblem,N1<:Number,N2<:Number,M<:AbstractMatrix{N1},V<:AbstractVector{N2}} <: AbstractMasterProblem{ST}
-    A::M  # constraint matrix in original formulation
-    b::V  # right-hand side of linkin constraints
+mutable struct SimpleMasterProblem{ST<:AbstractSubProblem, N1<:Number, V<:AbstractVector{N1}} <: AbstractMasterProblem{ST}
+    
+    b::V  # right-hand side of linking constraints
 
     rmp::MathProgBase.AbstractLinearQuadraticModel  # restricted Master Problem
     sp::ST  # sub-problem
-    SimpleMasterProblem(A::M,b::V,rmp::MathProgBase.AbstractLinearQuadraticModel,sp::ST) where {ST<:AbstractSubProblem,N1<:Number,N2<:Number,M<:AbstractMatrix{N1},V<:AbstractVector{N2}} =
-        new{ST,N1,N2,M,V}(A,b,rmp,sp)
+
+    SimpleMasterProblem(
+        b::V,
+        rmp::MathProgBase.AbstractLinearQuadraticModel,
+        sp::ST
+    ) where {ST<:AbstractSubProblem, N1<:Number, V<:AbstractVector{N1}} =
+        new{ST,N1,V}(b, rmp, sp)
 end
 
 # TODO build convenient constructor functions for SimpleMasterProblem
 function SimpleMasterProblem(
-    A::M,
-    senses::V1,
-    b::V2,
+    b::V,
+    senses::Vector{Char},
     solver::MathProgBase.AbstractMathProgSolver,
     sp::ST
-) where {N1<:Number, N2<:Number, M<:AbstractMatrix{N1},V1<:AbstractVector{Char},V2<:AbstractVector{N2},ST<:AbstractSubProblem}
+) where {N1<:Number, V<:AbstractVector{N1},ST<:AbstractSubProblem}
 
     # dimension check
-    nlinkingconstrs = size(A, 1)  # number of linking constraints
+    nlinkingconstrs = size(b, 1)  # number of linking constraints
     nlinkingconstrs == size(senses, 1) || DimensionMismatch("")
-    nlinkingconstrs == size(b, 1) || DimensionMismatch("")
+
     # instanciate rmp
     rmp = MathProgBase.LinearQuadraticModel(solver)
 
@@ -143,10 +164,11 @@ function SimpleMasterProblem(
             error("Invalid input: senses[$(j)]=$(senses[j])")
         end
     end
-    MathProgBase.addconstr!(rmp, [], [], 1.0, 1.0)  # convexity constraint
+    MathProgBase.addconstr!(rmp, zeros(), zeros(), 1.0, 1.0)  # convexity constraint
 
-    return SimpleMasterProblem(A, b, rmp, sp)
+    return SimpleMasterProblem(b, rmp, sp)
 end
+
 
 """
     subproblem
@@ -167,7 +189,7 @@ function compute_dual_variables!(mp::SimpleMasterProblem{ST}) where {ST<:Abstrac
     rmp_status = find_status(MathProgBase.status(mp.rmp))
 
     # check RMP status
-    nlinkingconstrs = size(mp.A, 1)
+    nlinkingconstrs = size(mp.b, 1)
     if !ok(rmp_status)
         # unexpected status when solving RMP
         # TODO: handle dual unboundedness in RMP
@@ -176,11 +198,8 @@ function compute_dual_variables!(mp::SimpleMasterProblem{ST}) where {ST<:Abstrac
     else
         # RMP solved to optimality
         dualsolution = MathProgBase.getconstrduals(mp.rmp)
-        π = (mp.A)' * dualsolution[1:nlinkingconstrs]  # project dual vector to original space
+        π = dualsolution[1:nlinkingconstrs]
         σ = dualsolution[nlinkingconstrs+1:end]
-        # println("\tMaster: RMP solved to optimality")
-        # println("\t\tπ=", π)
-        # println("\t\tσ=", σ)
     end
 
     return MasterSolution(rmp_status, π, σ)
@@ -190,7 +209,7 @@ function add_columns!(mp::SimpleMasterProblem{ST}, columns::Vector{Column}) wher
     ncols = size(columns, 1)
     ncolsadded = 0
 
-    constridx = collect(1:(1+size(mp.A, 1)))  # assume only one sub-problem
+    constridx = collect(1:(1+size(mp.b, 1)))  # assume only one sub-problem
     for column in columns
         # add column (assumed to have negative reduced cost)
         if column.isactive
@@ -199,10 +218,10 @@ function add_columns!(mp::SimpleMasterProblem{ST}, columns::Vector{Column}) wher
         ncolsadded += 1
         if column.isvertex
             # extreme vertex
-            constrcoeff = vcat(mp.A * column.col, [1.0])
+            constrcoeff = vcat(column.col, [1.0])
         else
             # extreme ray
-            constrcoeff = vcat(mp.A * column.col, [0.0])
+            constrcoeff = vcat(column.col, [0.0])
         end
         MathProgBase.addvar!(mp.rmp, constridx, constrcoeff, 0.0, Inf, column.cost)
         column.isactive = true

--- a/test/simple_subproblem.jl
+++ b/test/simple_subproblem.jl
@@ -1,6 +1,8 @@
 import Linda.SimpleProblem
 
-A = [
+A_link = eye(2)
+
+A_sub = [
     1 1
     1 2
 ]
@@ -10,8 +12,8 @@ c = [-1;-1]
 sense = ['<','<']
 vartypes = [:Int,:Int]
 
-sp = Linda.SimpleProblem.SimpleSubProblem(c,A,['<','<'],b, vartypes, [0,0],[Inf,Inf],CbcSolver())
-presult = Linda.solve_pricing(sp,[0.0;0.0],[0.0])
+sp = Linda.SimpleProblem.SimpleSubProblem(c, A_link, A_sub, ['<','<'], b, vartypes, [0,0], [Inf,Inf], CbcSolver())
+presult = Linda.solve_pricing(sp, [0.0;0.0], [0.0])
 @test presult.status == Linda.StatusOptimal()
 @test size(presult.columns) == (1,)
 # @test size(columns) == (2,1)


### PR DESCRIPTION
Alleviates the need to project dual variables and columns within SimpleMasterProblem.

This will make it easier to write custom implementations without having to re-write code for the Master Problem.